### PR TITLE
Add CSRF middleware and auth request validation

### DIFF
--- a/app/Http/Middleware/DisableCsrfForPosts.php
+++ b/app/Http/Middleware/DisableCsrfForPosts.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
+
+class DisableCsrfForPosts extends Middleware
+{
+    protected $except = [
+        'posts',
+        'posts/*',
+    ];
+}

--- a/app/Http/Middleware/EnsureTokenIsValid.php
+++ b/app/Http/Middleware/EnsureTokenIsValid.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureTokenIsValid
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        return $next($request);
+    }
+}

--- a/app/Http/Requests/AuthManagement/AuthLoginRequest.php
+++ b/app/Http/Requests/AuthManagement/AuthLoginRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\AuthManagement;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AuthLoginRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'email' => 'required|string|email',
+            'password' => 'required|string|min:6',
+        ];
+    }
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+}

--- a/app/Http/Requests/AuthManagement/AuthRegisterRequest.php
+++ b/app/Http/Requests/AuthManagement/AuthRegisterRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\AuthManagement;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AuthRegisterRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:50|min:3',
+            //'name' => ['required', 'string', 'max:255'],
+            'email' => 'required|string|email|max:50|unique:users,email',
+            'password' => 'required|string|min:6|confirmed',
+        ];
+    }
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Introduces DisableCsrfForPosts middleware to exclude 'posts' routes from CSRF verification and EnsureTokenIsValid middleware as a placeholder for token validation. Adds AuthLoginRequest and AuthRegisterRequest classes to handle validation for login and registration endpoints.